### PR TITLE
Added flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/eiannone/keyboard"
@@ -83,27 +85,27 @@ func secToMins(t ClockTime) (mins, secs uint) {
 }
 
 func main() {
-
-	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stdin, "Usage: chessclk <TIME_SECONDS>")
-		os.Exit(1)
-	}
-
 	var gameTime ClockTime = 0
 
-	// If user supplied times, usse for both openents.
-	// TODO: Refactor with proper flags interface.
-	if os.Args[1] != "" {
-		initTime := os.Args[1]
-		m, err := time.ParseDuration((initTime))
+	// flags for the different game modes, and a custom time
+	gameMode := flag.String("m", "rapid", "Game modes: \n- \"rapid\" (15 min)\n- \"blitz\" (3 min)\n- \"classical\" (120 min)\n- Define a custom time: \"-m time 60\"\n")
+
+	flag.Parse()
+
+	switch *gameMode {
+	case "blitz":
+		gameTime = ClockTime(180)
+	case "classical":
+		gameTime = ClockTime(7200)
+	case "time":
+		secs, err := strconv.Atoi(flag.Args()[0])
 		if err != nil {
-			log.Fatal("error parsing time argument")
+			pterm.Warning.Println("[+] Invalid time given")
+			os.Exit(1)
 		}
-		// Convert to proper type
-		gameTime = ClockTime(m.Round(time.Second).Seconds())
-	} else {
-		log.Println("No argument passed, will use default time value of 15 mins")
-		gameTime = ClockTime(15 * 60)
+		gameTime = ClockTime(secs)
+	default:
+		gameTime = ClockTime(900)
 	}
 
 	// Make sure our clock isn't set to a useless zero.

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 	var gameTime ClockTime = 0
 
 	// flags for the different game modes, and a custom time
-	gameMode := flag.String("m", "rapid", "Game modes: \n- \"rapid\" (15 min)\n- \"blitz\" (3 min)\n- \"classical\" (120 min)\n- Define a custom time: \"-m time 60\"\n")
+	gameMode := flag.String("m", "rapid", "Game modes: \n- \"rapid\" (15 min)\n- \"blitz\" (3 min)\n- \"classical\" (120 min)\n- Define a custom time (in secs): \"-m time 60\"\n")
 
 	flag.Parse()
 


### PR DESCRIPTION
Added flags interface:

- default time is still 15 minutes
- supported modes are rapid, blitz (3 minutes) and classical (120 minutes)
- you can set a custom time like this `-m time 300`
- used the standard golang flags package, `-h` or `--help` will show usage:
```
  -m string
        Game modes: 
        - "rapid" (15 min)
        - "blitz" (3 min)
        - "classical" (120 min)
        - Define a custom time (in secs): "-m time 60"
         (default "rapid")
```